### PR TITLE
Cheyu/save to favorite btns toggle

### DIFF
--- a/templates/partials/post_bar.tpl
+++ b/templates/partials/post_bar.tpl
@@ -13,9 +13,14 @@
 				<!-- IMPORT partials/topic/sort.tpl -->
 				<!-- IMPORT partials/topic/tools.tpl -->
 
-				<button component="topic/save-to-favorites" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
+				<button component="topic/favorite" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
 					<i class="fa fa-fw fa-regular fa-star text-primary"></i>
-					<span class="d-none d-md-inline fw-semibold">Save to Favorites</span>
+					<span class="d-none d-md-inline fw-semibold">[[topic:favorite]]</span>
+				</button>
+
+				<button component="topic/unfavorite" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center hidden">
+					<i class="fa fa-fw fa-solid fa-star text-primary"></i>
+					<span class="d-none d-md-inline fw-semibold">[[topic:unfavorite]]</span>
 				</button>
 
 				{{{ if (!feeds:disableRSS && rssFeedUrl) }}}

--- a/templates/partials/topic-list-bar.tpl
+++ b/templates/partials/topic-list-bar.tpl
@@ -26,6 +26,11 @@
 				{{{ end }}}
 				<!-- IMPORT partials/category/tools.tpl -->
 
+				<button component="topic/save-to-favorites" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
+					<i class="fa fa-fw fa-regular fa-star text-primary"></i>
+					<span class="d-none d-md-inline fw-semibold">Favorite Posts</span>
+				</button>
+
 				{{{ if (!feeds:disableRSS && rssFeedUrl) }}}
 				<a class="btn-ghost-sm d-none d-lg-flex align-self-stretch" target="_blank" href="{rssFeedUrl}" itemprop="item" title="[[global:rss-feed]]"><i class="fa fa-rss text-primary"></i></a>
 				{{{ end }}}
@@ -33,11 +38,6 @@
 				<a href="{{{ if template.category }}}{url}{{{ else }}}{config.relative_path}/{selectedFilter.url}{querystring}{{{ end }}}" class="btn btn-secondary fw-semibold position-absolute top-100 translate-middle-x start-50 mt-1 hide" style="--bs-btn-padding-y: .25rem; --bs-btn-padding-x: .5rem; --bs-btn-font-size: .75rem;" id="new-topics-alert">
 					<i class="fa fa-fw fa-arrow-up"></i> [[recent:load-new-posts]]
 				</a>
-
-				<button component="topic/save-to-favorites" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
-					<i class="fa fa-fw fa-regular fa-star text-primary"></i>
-					<span class="d-none d-md-inline fw-semibold">Favorite Posts</span>
-				</button>
 			</div>
 
 			<div class="d-flex gap-1 align-items-center">


### PR DESCRIPTION
Created buttons to favorite and unfavorite posts. Adjusted the layout of the favorite button on the category page.
This resolves https://github.com/CMU-313/nodebb-f24-sweethearts/issues/1

To test the behavior, click on any topic, and you should see a "Save to Favorites" button on the menu bar. 
Clicking on the button will switch it to "Remove from Favorites".
Clicking on it again will switch it back to "Save to Favorites".