### PR TITLE
Old - Created a Favorites Button for each Topic in Discussions page

### DIFF
--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -10,9 +10,9 @@
 
 		<div class="d-flex p-0 col-12 col-lg-7 gap-2 gap-lg-3 pe-1 align-items-start {{{ if config.theme.mobileTopicTeasers }}}mb-2 mb-lg-0{{{ end }}}">
 			<div class="flex-shrink-0 position-relative">
-				<a class="text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
-					{buildAvatar(./user, "40px", true, "avatar avatar-tooltip")}
-				</a>
+				<button component="topic/save-to-favorites" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
+					<i class="fa fa-fw fa-regular fa-star text-primary"></i>
+				</button>
 				{{{ if showSelect }}}
 				<div class="checkbox position-absolute top-100 start-50 translate-middle-x pt-2 m-0 d-none d-lg-flex" style="max-width:max-content">
 					<i component="topic/select" class="fa text-muted pointer fa-square-o p-1 hover-visible"></i>
@@ -20,6 +20,11 @@
 				{{{ end }}}
 			</div>
 			<div class="flex-grow-1 d-flex flex-wrap gap-1 position-relative">
+				<a class="text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
+					{buildAvatar(./user, "40px", true, "avatar avatar-tooltip")}
+				</a>
+			</div>
+			<div class="flex-grow-1 d-flex flex-wrap gap-1 align-items-start">
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -13,18 +13,20 @@
 				<button component="topic/save-to-favorites" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
 					<i class="fa fa-fw fa-regular fa-star text-primary"></i>
 				</button>
+			</div>
+			<div class="flex-shrink-0 position-relative">
 				{{{ if showSelect }}}
-				<div class="checkbox position-absolute top-100 start-50 translate-middle-x pt-2 m-0 d-none d-lg-flex" style="max-width:max-content">
-					<i component="topic/select" class="fa text-muted pointer fa-square-o p-1 hover-visible"></i>
+				<div class="checkbox d-flex gap-2 align-items-center" style="max-width:max-content">
+					<i component="topic/select" class="fa text-muted pointer fa-square-o"></i>
 				</div>
 				{{{ end }}}
 			</div>
-			<div class="flex-grow-1 d-flex flex-wrap gap-1 position-relative">
+			<div class="flex-shrink-0 gap-0 p-0 align-items-start">
 				<a class="text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
 					{buildAvatar(./user, "40px", true, "avatar avatar-tooltip")}
 				</a>
 			</div>
-			<div class="flex-grow-1 d-flex flex-wrap gap-1 align-items-start">
+			<div class="flex-grow-2 d-flex flex-wrap gap-1 position-relative">
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>


### PR DESCRIPTION
This pull request solves Issue #31 in the main repository (https://github.com/CMU-313/nodebb-f24-sweethearts/issues/31). Below is an explanation for the commits.
_______

Pulled Cheyu's 'Favorite Posts' category in the post_bar.tpl. Did this a while ago, but forgot I realize I committed changes in the wrong branch.

Added the star button to the discussion page; however, formatting looked off. I wanted it to replicate the Gmail select and favorites button in the inbox section. I also committed these changes in the wrong branch.

Then replicated the Gmail inbox UI, with the star, square select button, and header next to each other instead of on top.